### PR TITLE
Skipping special tokens and adding generation prompt for instruct model

### DIFF
--- a/src/generate_model_answers.py
+++ b/src/generate_model_answers.py
@@ -212,7 +212,7 @@ def generate_model_answers(data, model, tokenizer, device, model_name, do_sample
             model_output = generate(model_input, model, model_name, do_sample, output_scores, max_new_tokens=max_new_tokens,
                                     top_p=top_p, temperature=temperature, stop_token_id=stop_token_id, tokenizer=tokenizer)
 
-        answer = tokenizer.decode(model_output['sequences'][0][len(model_input[0]):])
+        answer = tokenizer.decode(model_output['sequences'][0][len(model_input[0]):], skip_special_tokens=True)
         if output_scores:
             scores = torch.concatenate(model_output['scores']).cpu()  # shape = (new_tokens, len(vocab))
             all_scores.append(scores)

--- a/src/generate_model_answers.py
+++ b/src/generate_model_answers.py
@@ -212,7 +212,10 @@ def generate_model_answers(data, model, tokenizer, device, model_name, do_sample
             model_output = generate(model_input, model, model_name, do_sample, output_scores, max_new_tokens=max_new_tokens,
                                     top_p=top_p, temperature=temperature, stop_token_id=stop_token_id, tokenizer=tokenizer)
 
-        answer = tokenizer.decode(model_output['sequences'][0][len(model_input[0]):], skip_special_tokens=True)
+        if 'instruct' in model_name.lower():
+            answer = tokenizer.decode(model_output['sequences'][0][len(model_input[0]):], skip_special_tokens=True)
+        else:
+            answer = tokenizer.decode(model_output['sequences'][0][len(model_input[0]):])
         if output_scores:
             scores = torch.concatenate(model_output['scores']).cpu()  # shape = (new_tokens, len(vocab))
             all_scores.append(scores)

--- a/src/probing_utils.py
+++ b/src/probing_utils.py
@@ -100,7 +100,12 @@ def tokenize(prompt, tokenizer, model_name, tokenizer_args=None):
         messages = [
             {"role": "user", "content": prompt}
         ]
-        model_input = tokenizer.apply_chat_template(messages, return_tensors="pt", **(tokenizer_args or {})).to('cuda')
+        model_input = tokenizer.apply_chat_template(
+            messages,
+            return_tensors="pt",
+            add_generation_prompt=True,
+            **(tokenizer_args or {}),
+        ).to('cuda')
     else: # non instruct model
         model_input = tokenizer(prompt, return_tensors='pt', **(tokenizer_args or {}))
         if "input_ids" in model_input:


### PR DESCRIPTION
Hi, I found that you use `tokenizer.apply_chat_template` for the generation of instruct model, but didn't add the prompt for continuing to generate. I have made the modifications as below:

- Adding the generation prompt indicating the start of a bot response.
- Skip special tokens after generation.