### PR TITLE
Fix argparse dataset restriction to allow test datasets

### DIFF
--- a/src/generate_model_answers.py
+++ b/src/generate_model_answers.py
@@ -22,7 +22,8 @@ def parse_args():
                         choices=LIST_OF_MODELS,
                         required=True)
     parser.add_argument("--dataset",
-                        choices=LIST_OF_DATASETS)
+                        required=True,
+                        help="Name of the dataset (e.g., triviaqa, triviaqa_test, etc.)")
     parser.add_argument("--verbose", action='store_true', help='print more information')
     parser.add_argument("--n_samples", type=int, help='number of examples to use', default=None)
 


### PR DESCRIPTION
#### Problem
`src/generate_model_answers.py` previously restricted `--dataset` via `argparse` `choices=LIST_OF_DATASETS`. This caused runs to fail at argument parsing time when using dataset names not present in the allowlist (e.g., `triviaqa_test`).

#### Change
- Removed the `choices` restriction for `--dataset`
- Made `--dataset` required and added a clearer help message

#### Impact
Allows running the script with both training and test dataset names (including `*_test` variants) without being blocked by argparse.

#### How to test
```bash
python src/generate_model_answers.py --model <model_name> --dataset triviaqa_test
```